### PR TITLE
Contact Section Updates (feature/contact-section-update)

### DIFF
--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -10,7 +10,7 @@ import { useToast } from 'context/ToastContext'; // Import useToast hook
 const ContactFormWrapper = styled.div`
   width: 100%;
 
-  @media (min-width: 1440px) {
+  ${({ theme }) => theme.mediaQueries.lg} {
     max-width: 50%;
   }
 `;

--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -10,7 +10,10 @@ import { useToast } from 'context/ToastContext'; // Import useToast hook
 const ContactFormWrapper = styled.div`
   width: 100%;
 
-  ${({ theme }) => theme.mediaQueries.lg} {
+  ${({ theme }) => theme.mediaQueries.md} {
+    max-width: 75%;
+  }
+  ${({ theme }) => theme.mediaQueries.xl} {
     max-width: 50%;
   }
 `;

--- a/src/components/ContactSection.jsx
+++ b/src/components/ContactSection.jsx
@@ -2,6 +2,16 @@ import styled from '@emotion/styled';
 import config from '../config/home';
 import ContactForm from './ContactForm';
 
+const ScrollTo = styled.div`
+  pointer-events: none;
+  position: absolute;
+  transform: translateY(-4rem);
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    transform: translateY(-2rem);
+  }
+`;
+
 const Section = styled.div`
   background-image: linear-gradient(
     ${({ theme }) => theme.colors.darkBlue},
@@ -9,13 +19,20 @@ const Section = styled.div`
   );
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
-  gap: 4rem;
-  max-width: 100vw;
-  padding: 2rem;
+  align-items: center;
+`;
 
-  @media (min-width: 768px) {
+const SectionContent = styled.div`
+  max-width: ${({ theme }) => theme.layouts.maxWidth};
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4rem;
+
+  padding: 4rem 2rem;
+
+  ${({ theme }) => theme.mediaQueries.md} {
     padding: 6rem;
   }
 `;
@@ -35,7 +52,7 @@ const Title = styled.h2`
   line-height: 5rem;
   letter-spacing: -2px;
 
-  @media (min-width: 768px) {
+  ${({ theme }) => theme.mediaQueries.md} {
     font-size: 6.4rem;
     line-height: 6.4rem;
   }
@@ -47,7 +64,7 @@ const Subtitle = styled.p`
   line-height: 1.8rem;
   letter-spacing: 0.1px;
 
-  @media (min-width: 768px) {
+  ${({ theme }) => theme.mediaQueries.md} {
     font-size: 2.4rem;
     line-height: 2.4rem;
     letter-spacing: -0.1px;
@@ -56,13 +73,18 @@ const Subtitle = styled.p`
 
 const ContactSection = () => {
   return (
-    <Section id="contact">
-      <SectionInfo>
-        <Title>{config.contact.title}</Title>
-        <Subtitle>{config.contact.subtitle}</Subtitle>
-      </SectionInfo>
-      <ContactForm />
-    </Section>
+    <>
+      <ScrollTo id="contact" aria-hidden={true}></ScrollTo>
+      <Section>
+        <SectionContent>
+          <SectionInfo>
+            <Title>{config.contact.title}</Title>
+            <Subtitle>{config.contact.subtitle}</Subtitle>
+          </SectionInfo>
+          <ContactForm />
+        </SectionContent>
+      </Section>
+    </>
   );
 };
 

--- a/src/components/ContactSection.jsx
+++ b/src/components/ContactSection.jsx
@@ -46,28 +46,18 @@ const SectionInfo = styled.div`
   gap: 0.5rem;
 `;
 const Title = styled.h2`
-  font-family: 'Poppins', sans-serif;
+  font-family: ${({ theme }) => theme.fonts.poppins};
   font-weight: 700;
-  font-size: 5rem;
-  line-height: 5rem;
-  letter-spacing: -2px;
-
-  ${({ theme }) => theme.mediaQueries.md} {
-    font-size: 6.4rem;
-    line-height: 6.4rem;
-  }
+  font-size: clamp(5rem, 8vw, 6.4rem);
+  line-height: clamp(5rem, 8vw, 6.4rem);
 `;
 const Subtitle = styled.p`
-  font-family: 'Manrope', sans-serif;
+  width: 100%;
+  font-family: ${({ theme }) => theme.fonts.manrope};
   font-weight: 400;
-  font-size: 1.8rem;
-  line-height: 1.8rem;
-  letter-spacing: 0.1px;
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
 
   ${({ theme }) => theme.mediaQueries.md} {
-    font-size: 2.4rem;
-    line-height: 2.4rem;
-    letter-spacing: -0.1px;
   }
 `;
 


### PR DESCRIPTION
Updated contact section with various improvements and fixes.

Main fix:
- Offset section id position by placing it in a div that is offset from the main section by a certain amount to prevent the section title from being cutoff by nav bar when using scroll to. 
- New section id div uses aria-hidden to prevent issues with screen readers and other accessibility tools.

This id offset method is to mainly prevent adding too much extra vertical space related to increasing section vertical padding. Adding more padding works but I noticed it's a lot more to scroll over on smaller screens and adds a slightly too big of a visual gap (in my opinion).

Other fixes:
- Updated section to use global site max width for large screens.
- Added clamp to font sizes to make them responsive.
- Added more breakpoints to form width to smooth out excessive visual snapping on page shrink or expand.
- Updated various font/color/media query references to refer to theme file for more consistency.

Related issue: #31 