### PR TITLE
Contact Page (feature/contact-page)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,7 @@ import Services from './pages/Services';
 import NotFound from './pages/404';
 import LoginPage from './pages/Login';
 import ProfilePage from './pages/Profile';
+import ContactPage from './pages/Contact';
 
 const App = () => {
   return (
@@ -35,6 +36,7 @@ const App = () => {
               <Route element={<Layout />}>
                 <Route path="/" element={<Home />} />
                 <Route path="/services" element={<Services />} />
+                <Route path="/contact" element={<ContactPage />} />
                 <Route path="*" element={<NotFound />} />
                 <Route
                   path="/profile"

--- a/src/components/organisms/ContactForm.jsx
+++ b/src/components/organisms/ContactForm.jsx
@@ -8,14 +8,15 @@ import FormContext from 'context/ContactForm';
 import { useToast } from 'context/ToastContext'; // Import useToast hook
 
 const ContactFormWrapper = styled.div`
-  width: 100%;
+  // width: 100%;
+  width: clamp(0rem, 100%, 100rem);
 
   ${({ theme }) => theme.mediaQueries.md} {
-    max-width: 75%;
+    // max-width: 75%;
   }
-  ${({ theme }) => theme.mediaQueries.xl} {
-    max-width: 50%;
-  }
+  // ${({ theme }) => theme.mediaQueries.xl} {
+  //   max-width: 50%;
+  // }
 `;
 const ContactFormStyled = styled.form`
   display: flex;

--- a/src/components/organisms/ContactForm.jsx
+++ b/src/components/organisms/ContactForm.jsx
@@ -8,15 +8,7 @@ import FormContext from 'context/ContactForm';
 import { useToast } from 'context/ToastContext'; // Import useToast hook
 
 const ContactFormWrapper = styled.div`
-  // width: 100%;
-  width: clamp(0rem, 100%, 100rem);
-
-  ${({ theme }) => theme.mediaQueries.md} {
-    // max-width: 75%;
-  }
-  // ${({ theme }) => theme.mediaQueries.xl} {
-  //   max-width: 50%;
-  // }
+  width: clamp(0rem, 100%, 160rem);
 `;
 const ContactFormStyled = styled.form`
   display: flex;

--- a/src/components/organisms/ContactSection.jsx
+++ b/src/components/organisms/ContactSection.jsx
@@ -18,13 +18,14 @@ const Section = styled.section`
     ${({ theme }) => theme.colors.fuchsia}
   );
   ${({ theme }) => theme.mixins.flexColCenter};
-  padding: ${({ theme }) => theme.layouts.sectionPadding};
+  padding: ${({ theme }) => theme.layouts.sectionPaddingNoTop};
+  padding-top: clamp(6rem, 6vw, 8rem);
+  padding-bottom: clamp(4rem, 4vw, 6rem);
 `;
 
 const SectionContent = styled.div`
   max-width: ${({ theme }) => theme.layouts.maxWidth};
   width: 100%;
-  min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/src/components/organisms/ContactSection.jsx
+++ b/src/components/organisms/ContactSection.jsx
@@ -24,9 +24,11 @@ const Section = styled.section`
 const SectionContent = styled.div`
   max-width: ${({ theme }) => theme.layouts.maxWidth};
   width: 100%;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  justify-content: center;
   gap: 4rem;
 `;
 const SectionInfo = styled.div`

--- a/src/components/organisms/ContactSection.jsx
+++ b/src/components/organisms/ContactSection.jsx
@@ -13,10 +13,6 @@ const ScrollTo = styled.div`
 `;
 
 const Section = styled.section`
-  background-image: linear-gradient(
-    ${({ theme }) => theme.colors.darkBlue},
-    ${({ theme }) => theme.colors.fuchsia}
-  );
   ${({ theme }) => theme.mixins.flexColCenter};
   padding: ${({ theme }) => theme.layouts.sectionPaddingNoTop};
   padding-top: clamp(6rem, 6vw, 8rem);

--- a/src/components/organisms/SocialsArea.jsx
+++ b/src/components/organisms/SocialsArea.jsx
@@ -1,2 +1,0 @@
-const SocialsArea = () => {};
-export default SocialsArea;

--- a/src/components/organisms/SocialsArea.jsx
+++ b/src/components/organisms/SocialsArea.jsx
@@ -1,0 +1,2 @@
+const SocialsArea = () => {};
+export default SocialsArea;

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,6 +1,19 @@
+import styled from '@emotion/styled';
 import ContactSection from '../components/organisms/ContactSection';
 
+const PageWrapper = styled.div`
+  min-height: 100vh;
+  background-image: linear-gradient(
+    ${({ theme }) => theme.colors.darkBlue},
+    ${({ theme }) => theme.colors.fuchsia}
+  );
+`;
+
 const ContactPage = () => {
-  return <ContactSection />;
+  return (
+    <PageWrapper>
+      <ContactSection />
+    </PageWrapper>
+  );
 };
 export default ContactPage;

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,0 +1,10 @@
+import ContactSection from '../components/organisms/ContactSection';
+
+const Contact = () => {
+  return (
+    <>
+      <ContactSection />
+    </>
+  );
+};
+export default Contact;

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,10 +1,10 @@
 import ContactSection from '../components/organisms/ContactSection';
 
-const Contact = () => {
+const ContactPage = () => {
   return (
     <>
       <ContactSection />
     </>
   );
 };
-export default Contact;
+export default ContactPage;

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,12 +1,6 @@
 import ContactSection from '../components/organisms/ContactSection';
-import SocialsArea from '../components/organisms/SocialsArea';
 
 const ContactPage = () => {
-  return (
-    <>
-      <ContactSection />
-      <SocialsArea />
-    </>
-  );
+  return <ContactSection />;
 };
 export default ContactPage;

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,9 +1,11 @@
 import ContactSection from '../components/organisms/ContactSection';
+import SocialsArea from '../components/organisms/SocialsArea';
 
 const ContactPage = () => {
   return (
     <>
       <ContactSection />
+      <SocialsArea />
     </>
   );
 };

--- a/src/style/layouts.js
+++ b/src/style/layouts.js
@@ -2,6 +2,7 @@
 const layouts = {
   maxWidth: '2000px',
   sectionPadding: '4rem clamp(2rem, 6vw, 8rem)',
+  sectionPaddingNoTop: '0rem clamp(2rem, 6vw, 8rem)',
 };
 
 export default layouts;


### PR DESCRIPTION
Creation of the dedicated contact page. Based on the original contact form component adjusted to work better with a full page layout. 

The main technical change to the old component is splitting off the background gradient and adding it to the new page instead. This will allow for the gradient to continue in case we want to add additional elements to the page under the form (such as a social icon). 

This page has been added to the routing in app.js. Previous references to /contact should now work to lead to this page.

Related issue #62 