### PR TITLE
Site Mobile Margin Fix

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <!-- Existing head content -->
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="description" content="Transpiled Web" />
     <title>Transpiled</title>
     <link rel="stylesheet" href="./index.css" />


### PR DESCRIPTION
On the mobile version of the site, when the viewing device is in landscape mode, the margins of the page do not extend the full width; this change aims to fix that. 

See screenshots below. Top picture is before, bottom is after.

![IMG_4530](https://github.com/user-attachments/assets/2d65fb39-0810-4f80-b135-d2fcb47b730a)
![IMG_4531](https://github.com/user-attachments/assets/8a601679-9b1a-4c95-bf8f-3596b44837b8)

Related issue: #75 