### PR TITLE
Update Header Transition (feature/header-transition)

### DIFF
--- a/src/components/organisms/Header.jsx
+++ b/src/components/organisms/Header.jsx
@@ -50,7 +50,7 @@ const Nav = styled.nav`
   gap: 2rem;
 `;
 
-const SampleHeader = () => {
+const Header = () => {
   const { scrolled, handleScroll } = useContext(GlobalContext);
   const { menuOpen, toggleMenu } = useContext(GlobalContext);
   const { currentUser } = useContext(AuthContext);
@@ -77,4 +77,4 @@ const SampleHeader = () => {
   );
 };
 
-export default SampleHeader;
+export default Header;

--- a/src/context/GlobalContext.js
+++ b/src/context/GlobalContext.js
@@ -43,7 +43,7 @@ export const GlobalProvider = ({ children }) => {
 
   // Update the scrolled state
   const handleScroll = () => {
-    setScrolled(window.scrollY > 50);
+    setScrolled(window.scrollY > 0);
   };
 
   return (


### PR DESCRIPTION
Updated the header background color fade in on scroll to take place immediately (previously had a delay) by updating the global context file. 

Related issue: #86 