### PR TITLE
Implement no scroll when menu is open (feature/no-scroll)

### DIFF
--- a/src/components/organisms/Header.jsx
+++ b/src/components/organisms/Header.jsx
@@ -9,6 +9,7 @@ import MobileNavMenu from 'organisms/MobileNavMenu';
 import MobileMenuButton from 'atoms/MobileMenuButton';
 import links from 'data/navigation';
 import ProfileDropdown from 'organisms/ProfileDropdown';
+import useNoScroll from '../../hooks/useNoScroll';
 
 const HeaderContainer = styled.header`
   width: 100%;
@@ -69,6 +70,8 @@ const Header = () => {
 
   // Only show profile when we're not loading and the user is authenticated
   const showProfile = !loading && isAuthenticated && currentUser;
+
+  useNoScroll(menuOpen);
 
   return (
     <HeaderContainer scrolled={scrolled}>

--- a/src/hooks/useNoScroll.js
+++ b/src/hooks/useNoScroll.js
@@ -1,19 +1,17 @@
 import { useEffect } from 'react';
 
-// Custom hook to lock/unlock scroll on the body
 const useNoScroll = (isMenuOpen) => {
   useEffect(() => {
     if (isMenuOpen) {
-      document.body.style.overflow = 'hidden'; // Disable scroll
+      document.body.style.overflow = 'hidden';
     } else {
-      document.body.style.overflow = 'auto'; // Enable scroll
+      document.body.style.overflow = 'auto';
     }
 
-    // Cleanup to ensure scroll is restored when component unmounts
     return () => {
-      document.body.style.overflow = 'auto'; // Reset to default
+      document.body.style.overflow = 'auto';
     };
-  }, [isMenuOpen]); // Effect runs whenever the menu open state changes
+  }, [isMenuOpen]);
 };
 
 export default useNoScroll;

--- a/src/hooks/useNoScroll.js
+++ b/src/hooks/useNoScroll.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+// Custom hook to lock/unlock scroll on the body
+const useNoScroll = (isMenuOpen) => {
+  useEffect(() => {
+    if (isMenuOpen) {
+      document.body.style.overflow = 'hidden'; // Disable scroll
+    } else {
+      document.body.style.overflow = 'auto'; // Enable scroll
+    }
+
+    // Cleanup to ensure scroll is restored when component unmounts
+    return () => {
+      document.body.style.overflow = 'auto'; // Reset to default
+    };
+  }, [isMenuOpen]); // Effect runs whenever the menu open state changes
+};
+
+export default useNoScroll;


### PR DESCRIPTION
Added a hook that hides the webpage overflow when the nav menu is open. 

Related to issue #72 