### PR TITLE
Add dynamic copyright date into footer (feature/dynamic-year)

### DIFF
--- a/src/components/molecules/MiniFooter.jsx
+++ b/src/components/molecules/MiniFooter.jsx
@@ -36,10 +36,12 @@ const CopyRight = styled.div`
 const MiniFooter = () => {
   const { isVisible, scrollToTop } = useScrollToTop();
 
+  const currentYear = new Date().getFullYear();
+
   return (
     <ContentWrapper>
       <CopyRight>
-        <Icon name="FaCopyright" size={1.5} /> Transpiled 2024
+        <Icon name="FaCopyright" size={1.5} /> Transpiled {currentYear}
       </CopyRight>
       {isVisible && (
         <ScrollTop aria-label="Scroll to top" onClick={scrollToTop}>


### PR DESCRIPTION
Updated the copyright date in the footer to use whatever the current year is. Should keep the site looking up to date without requiring us to remember to constantly change it. 

Issue #137 