### PR TITLE
Add animation to mobile header (enhance/header-animation)

### DIFF
--- a/src/components/organisms/MobileNavMenu.jsx
+++ b/src/components/organisms/MobileNavMenu.jsx
@@ -7,7 +7,7 @@ import GlobalContext from 'context/GlobalContext';
 const StyledMobileNav = styled.nav`
   min-height: 100vh;
   width: 100%;
-  background-color: ${({ theme }) => theme.colors.black};
+  // background-color: ${({ theme }) => theme.colors.black};
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -20,8 +20,8 @@ const StyledMobileNav = styled.nav`
   transition:
     opacity 0.3s ease,
     visibility 0.3s ease;
-  opacity: ${({ ariaHidden }) => (ariaHidden ? 0 : 1)};
-  visibility: ${({ ariaHidden }) => (ariaHidden ? 'hidden' : 'visible')};
+  // opacity: ${({ ariaHidden }) => (ariaHidden ? 0 : 1)};
+  // visibility: ${({ ariaHidden }) => (ariaHidden ? 'hidden' : 'visible')};
 `;
 
 const StyledLink = styled(Link)`
@@ -33,18 +33,35 @@ const StyledLink = styled(Link)`
   position: relative;
 `;
 
+const BgOverlay = styled.div`
+  background-color: ${({ theme }) => theme.colors.black};
+  height: 100%;
+  width: 100%;
+  content: '';
+  position: fixed;
+  z-index: -1;
+  transform: scaleY(${({ isOpen }) => (isOpen ? '1' : '0')});
+  transform-origin: top;
+  transition: transform 0.3s ease;
+`;
+
 const MobileNavMenu = ({ links }) => {
   const { menuOpen, toggleMenu } = useContext(GlobalContext);
 
-  if (!menuOpen) return null;
+  // if (!menuOpen) return null;
 
   return (
-    <StyledMobileNav aria-hidden={!menuOpen}>
+    <StyledMobileNav isOpen={menuOpen} aria-hidden={!menuOpen}>
       {links.map(({ url, label }) => (
         <StyledLink key={url} to={url} onClick={toggleMenu} aria-label={label}>
           {label}
         </StyledLink>
       ))}
+      <BgOverlay
+        isOpen={menuOpen}
+        aria-hidden={true}
+        aria-label="menu background overlay"
+      ></BgOverlay>
     </StyledMobileNav>
   );
 };

--- a/src/components/organisms/MobileNavMenu.jsx
+++ b/src/components/organisms/MobileNavMenu.jsx
@@ -5,8 +5,7 @@ import { Link } from 'react-router-dom';
 import GlobalContext from 'context/GlobalContext';
 
 const StyledMobileNav = styled.nav`
-  min-height: 100vh;
-  height: 100%;
+  height: 100vh;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -34,7 +33,6 @@ const StyledLink = styled(Link)`
   font-weight: 400;
   font-size: clamp(2rem, 2vw, 2.4rem);
   letter-spacing: -0.015em;
-  position: relative;
   opacity: ${({ isOpen }) => (isOpen ? '1' : '0')};
   transition: opacity 0.4s ease;
   transition-delay: ${({ delay }) => `${delay}s`};
@@ -44,10 +42,9 @@ const BgOverlay = styled.div`
   background-color: ${({ theme }) => theme.colors.black};
   height: 100%;
   width: 100%;
-  content: '';
+  position: fixed;
   top: 0;
   left: 0;
-  position: fixed;
   z-index: -1;
   transform: scaleY(${({ isOpen }) => (isOpen ? '1' : '0')});
   transform-origin: top;
@@ -80,11 +77,7 @@ const MobileNavMenu = ({ links }) => {
           </StyledLink>
         ))}
       </StyledMobileNav>
-      <BgOverlay
-        isOpen={menuOpen}
-        aria-hidden={true}
-        aria-label="menu background overlay"
-      ></BgOverlay>
+      <BgOverlay isOpen={menuOpen} aria-label="menu background overlay" />
     </>
   );
 };

--- a/src/components/organisms/MobileNavMenu.jsx
+++ b/src/components/organisms/MobileNavMenu.jsx
@@ -6,8 +6,8 @@ import GlobalContext from 'context/GlobalContext';
 
 const StyledMobileNav = styled.nav`
   min-height: 100vh;
+  height: 100%;
   width: 100%;
-  // background-color: ${({ theme }) => theme.colors.black};
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -20,8 +20,8 @@ const StyledMobileNav = styled.nav`
   transition:
     opacity 0.3s ease,
     visibility 0.3s ease;
-  // opacity: ${({ ariaHidden }) => (ariaHidden ? 0 : 1)};
-  // visibility: ${({ ariaHidden }) => (ariaHidden ? 'hidden' : 'visible')};
+  visibility: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
+  opacity: ${({ isOpen }) => (isOpen ? '1' : '0')};
 `;
 
 const StyledLink = styled(Link)`
@@ -38,31 +38,41 @@ const BgOverlay = styled.div`
   height: 100%;
   width: 100%;
   content: '';
+  top: 0;
+  left: 0;
   position: fixed;
   z-index: -1;
   transform: scaleY(${({ isOpen }) => (isOpen ? '1' : '0')});
   transform-origin: top;
-  transition: transform 0.3s ease;
+  visibility: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
+  transition:
+    transform 0.3s ease,
+    visibility 0.3s ease;
 `;
 
 const MobileNavMenu = ({ links }) => {
   const { menuOpen, toggleMenu } = useContext(GlobalContext);
 
-  // if (!menuOpen) return null;
-
   return (
-    <StyledMobileNav isOpen={menuOpen} aria-hidden={!menuOpen}>
-      {links.map(({ url, label }) => (
-        <StyledLink key={url} to={url} onClick={toggleMenu} aria-label={label}>
-          {label}
-        </StyledLink>
-      ))}
+    <>
+      <StyledMobileNav isOpen={menuOpen} aria-hidden={!menuOpen}>
+        {links.map(({ url, label }) => (
+          <StyledLink
+            key={url}
+            to={url}
+            onClick={toggleMenu}
+            aria-label={label}
+          >
+            {label}
+          </StyledLink>
+        ))}
+      </StyledMobileNav>
       <BgOverlay
         isOpen={menuOpen}
         aria-hidden={true}
         aria-label="menu background overlay"
       ></BgOverlay>
-    </StyledMobileNav>
+    </>
   );
 };
 

--- a/src/components/organisms/MobileNavMenu.jsx
+++ b/src/components/organisms/MobileNavMenu.jsx
@@ -22,6 +22,10 @@ const StyledMobileNav = styled.nav`
     visibility 0.4s ease;
   visibility: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
   opacity: ${({ isOpen }) => (isOpen ? '1' : '0')};
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    display: none;
+  }
 `;
 
 const StyledLink = styled(Link)`
@@ -48,6 +52,10 @@ const BgOverlay = styled.div`
   transition:
     transform 0.4s ease,
     visibility 0.4s ease;
+
+  ${({ theme }) => theme.mediaQueries.md} {
+    display: none;
+  }
 `;
 
 const MobileNavMenu = ({ links }) => {

--- a/src/components/organisms/MobileNavMenu.jsx
+++ b/src/components/organisms/MobileNavMenu.jsx
@@ -35,6 +35,9 @@ const StyledLink = styled(Link)`
   font-size: clamp(2rem, 2vw, 2.4rem);
   letter-spacing: -0.015em;
   position: relative;
+  opacity: ${({ isOpen }) => (isOpen ? '1' : '0')};
+  transition: opacity 0.4s ease;
+  transition-delay: ${({ delay }) => `${delay}s`};
 `;
 
 const BgOverlay = styled.div`
@@ -64,12 +67,14 @@ const MobileNavMenu = ({ links }) => {
   return (
     <>
       <StyledMobileNav isOpen={menuOpen} aria-hidden={!menuOpen}>
-        {links.map(({ url, label }) => (
+        {links.map(({ url, label }, index) => (
           <StyledLink
             key={url}
             to={url}
             onClick={toggleMenu}
             aria-label={label}
+            isOpen={menuOpen}
+            delay={menuOpen ? index * 0.1 : 0}
           >
             {label}
           </StyledLink>

--- a/src/components/organisms/MobileNavMenu.jsx
+++ b/src/components/organisms/MobileNavMenu.jsx
@@ -18,8 +18,8 @@ const StyledMobileNav = styled.nav`
   left: 0;
   z-index: ${({ theme }) => theme.zIndices.mobileNavOverlay};
   transition:
-    opacity 0.3s ease,
-    visibility 0.3s ease;
+    opacity 0.4s ease,
+    visibility 0.4s ease;
   visibility: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
   opacity: ${({ isOpen }) => (isOpen ? '1' : '0')};
 `;
@@ -46,8 +46,8 @@ const BgOverlay = styled.div`
   transform-origin: top;
   visibility: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
   transition:
-    transform 0.3s ease,
-    visibility 0.3s ease;
+    transform 0.4s ease,
+    visibility 0.4s ease;
 `;
 
 const MobileNavMenu = ({ links }) => {


### PR DESCRIPTION
Added animation to the mobile header for a more refined feeling. 

Instead of removing the header from the DOM, visibility is used to allow for transitioning. Media queries will still remove the elements entirely to avoid unnecessary component rendering in desktop view.

First of many enhancements to address issue #133. Always open to feedback!